### PR TITLE
fix warning and solve compatibility to A-Flow

### DIFF
--- a/plugin.tcl
+++ b/plugin.tcl
@@ -6,7 +6,7 @@ namespace eval ::plugins::${plugin_name} {
     variable author "Damian Brakel"
     variable contact "via Diaspora"
     variable description "D-Flow is a simple to use advanced profile"
-    variable version 2.1
+    variable version 2.3
     variable min_de1app_version {1.36.7}
 
 
@@ -219,6 +219,7 @@ if {[file exists "[homedir]/profiles/D-Flow____default.tcl"] != 1} {
 prep
 
 proc update_D-Flow {} {
+    set ::settings(espresso_temperature) $::Dflow_filling_temperature
     array set filling [lindex $::settings(advanced_shot) 0]
     array set soaking [lindex $::settings(advanced_shot) 1]
     array set pouring [lindex $::settings(advanced_shot) 2]
@@ -749,8 +750,6 @@ dui add dbutton $page_set 270 300 \
             fill_skin_listbox
             profile_has_changed_set_colors
             say [translate {Cancel}] $::settings(sound_button_in)
-            #set_next_page off off
-            #page_show off
             fill_advanced_profile_steps_listbox
             restore_espresso_chart
             save_settings_to_de1
@@ -932,9 +931,9 @@ dui add dbutton "settings_1 settings_3 settings_4" 642 0 1277 188 \
             -labelvariable {} -label_font [dui font get $font 12] -label_fill $font_colour -label_pos {0.5 0.5} \
             -command {
             set title_test [string range [ifexists ::settings(profile_title)] 0 7]
-            if {$title_test == "A-Flow /" && [info commands ::plugins::A_Flow_Espresso_Profile::prep] ne ""} {
-                ::plugins::A_Flow_Espresso_Profile::prep
-                ::plugins::A_Flow_Espresso_Profile::demo_graph
+            if {$title_test == "A-Flow /" && [info commands ::plugins::A_Flow::prep] ne ""} {
+                ::plugins::A_Flow::prep
+                ::plugins::A_Flow::demo_graph
                 if {$::settings(skin) == "DSx"} {
                     set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
                 } 
@@ -998,7 +997,6 @@ add_de1_button $page_set {save_settings_to_de1; set_alarms_for_de1_wake_sleep; s
             # if they were on the LIMITS tab of the Advanced profiles, reset the ui back to the main tab
             set ::settings(settings_profile_type) "Dflowset"
         }
-        
 
         #set_next_page off off; page_show off
         if {$::settings(skin) == "DSx"} {
@@ -1016,9 +1014,9 @@ add_de1_button $page_set {if {[ifexists ::profiles_hide_mode] == 1} { unset -noc
 dui add dbutton settings_1 1100 526 \
     -bwidth 200 -bheight 200 -tags new_profile_button -initial_state hidden \
     -command {
-        if {$title_test == "A-Flow /" && [info commands ::plugins::A_Flow_Espresso_Profile::prep] ne ""} {
-            ::plugins::A_Flow_Espresso_Profile::prep
-            ::plugins::A_Flow_Espresso_Profile::demo_graph
+        if {$title_test == "A-Flow /" && [info commands ::plugins::A_Flow::prep] ne ""} {
+            ::plugins::A_Flow::prep
+            ::plugins::A_Flow::demo_graph
             if {$::settings(skin) == "DSx"} {
                 set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
             }
@@ -1031,6 +1029,7 @@ dui add dbutton settings_1 1100 526 \
             }
             dui page load Dflowset
         }
+        dui page load Dflowset
     }
 
 dui add dbutton "settings_1" 1330 220 \
@@ -1038,9 +1037,9 @@ dui add dbutton "settings_1" 1330 220 \
     -labelvariable {} -label_font [dui font get $font 12] -label_fill $font_colour -label_pos {0.5 0.5} \
     -command {
     set title_test [string range [ifexists ::settings(profile_title)] 0 7]
-    if {$title_test == "A-Flow /" && [info commands ::plugins::A_Flow_Espresso_Profile::prep] ne ""} {
-        ::plugins::A_Flow_Espresso_Profile::prep
-        ::plugins::A_Flow_Espresso_Profile::demo_graph
+    if {$title_test == "A-Flow /" && [info commands ::plugins::A_Flow::prep] ne ""} {
+        ::plugins::A_Flow::prep
+        ::plugins::A_Flow::demo_graph
         if {$::settings(skin) == "DSx"} {
             set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
         }
@@ -1074,9 +1073,9 @@ add_de1_widget "settings_1c" graph 1330 300 {
     $::preview_graph_advanced axis configure y -color #5a5d75 -tickfont Helv_6 -min 0.0 -max 12 -majorticks {1 2 3 4 5 6 7 8 9 10 11 12} -title [translate "Advanced"] -titlefont Helv_8 -titlecolor #5a5d75;
     bind $::preview_graph_advanced [platform_button_press] {
         set title_test [string range [ifexists ::settings(profile_title)] 0 7]
-        if {$title_test == "A-Flow /" && [info commands ::plugins::A_Flow_Espresso_Profile::prep] ne ""} {
-            ::plugins::A_Flow_Espresso_Profile::prep
-            ::plugins::A_Flow_Espresso_Profile::demo_graph
+        if {$title_test == "A-Flow /" && [info commands ::plugins::A_Flow::prep] ne ""} {
+            ::plugins::A_Flow::prep
+            ::plugins::A_Flow::demo_graph
             if {$::settings(skin) == "DSx"} {
                 set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
             }
@@ -1096,8 +1095,8 @@ add_de1_widget "settings_1c" graph 1330 300 {
             set ::settings(active_settings_tab) $::settings(settings_profile_type)
             fill_advanced_profile_steps_listbox
             set_advsteps_scrollbar_dimensions
+            }
         }
-    }
 } -plotbackground #fff -width [rescale_x_skin 1050] -height [rescale_y_skin 450] -borderwidth 1 -background #FFFFFF -plotrelief raised  -plotpady 0 -plotpadx 10
 
 add_de1_button "settings_1" {say [translate {temperature}] $::settings(sound_button_in); change_espresso_temperature 0.5; profile_has_changed_set } 2380 230 2590 480
@@ -1160,5 +1159,20 @@ proc ::wrapped_profile_title {} {
         wrapped_profile_title_default
     }
 }
+
+proc show_d {args} {
+    if {[dui page current] == "settings_2c"} {
+        set title_test [string range [ifexists ::settings(profile_title)] 0 7]
+        if {$title_test == "D-Flow /" } {
+            ::plugins::D_Flow_Espresso_Profile::prep
+            ::plugins::D_Flow_Espresso_Profile::demo_graph
+            if {$::settings(skin) == "DSx"} {
+                set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
+            }
+            dui page load Dflowset
+        }
+    }
+}
+trace add execution show_settings {leave} ::plugins::D_Flow_Espresso_Profile::show_d
 
 }

--- a/plugin.tcl
+++ b/plugin.tcl
@@ -773,7 +773,9 @@ dui add dbutton $page_set 500 300 \
 dui add dbutton $page_set 85 555 \
     -bwidth 630 -bheight 230 \
     -shape outline -width $button_outline_width -outline $button_outline_colour \
-
+    -command {
+        # do nothing to avoid warning
+    }
 
 dui add dbutton $page_set 100 570 \
     -bwidth 600 -bheight 100 \
@@ -930,14 +932,21 @@ dui add dbutton "settings_1 settings_3 settings_4" 642 0 1277 188 \
             -labelvariable {} -label_font [dui font get $font 12] -label_fill $font_colour -label_pos {0.5 0.5} \
             -command {
             set title_test [string range [ifexists ::settings(profile_title)] 0 7]
-            if {$title_test == "D-Flow /" } {
+            if {$title_test == "A-Flow /" && [info commands ::plugins::A_Flow_Espresso_Profile::prep] ne ""} {
+                ::plugins::A_Flow_Espresso_Profile::prep
+                ::plugins::A_Flow_Espresso_Profile::demo_graph
+                if {$::settings(skin) == "DSx"} {
+                    set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
+                } 
+                dui page load Aflowset
+            } elseif {$title_test == "D-Flow /" } {
                 ::plugins::D_Flow_Espresso_Profile::prep
                 ::plugins::D_Flow_Espresso_Profile::demo_graph
                 if {$::settings(skin) == "DSx"} {
                     set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
                 }
                 dui page load Dflowset
-                } else {
+            } else {
                 after 500 update_de1_explanation_chart
                 say [translate {settings}] $::settings(sound_button_in)
                 set_next_page off $::settings(settings_profile_type)
@@ -981,11 +990,15 @@ add_de1_button $page_set {save_settings_to_de1; set_alarms_for_de1_wake_sleep; s
         set_next_page off message; page_show message
         after 200 app_exit
     } else {
-
+        if {[ifexists ::settings(settings_profile_type)] == "Aflowset"} {
+            # if they were on the LIMITS tab of the Advanced profiles, reset the ui back to the main tab
+            set ::settings(settings_profile_type) "Aflowset"
+        }
         if {[ifexists ::settings(settings_profile_type)] == "Dflowset"} {
             # if they were on the LIMITS tab of the Advanced profiles, reset the ui back to the main tab
             set ::settings(settings_profile_type) "Dflowset"
         }
+        
 
         #set_next_page off off; page_show off
         if {$::settings(skin) == "DSx"} {
@@ -1003,12 +1016,21 @@ add_de1_button $page_set {if {[ifexists ::profiles_hide_mode] == 1} { unset -noc
 dui add dbutton settings_1 1100 526 \
     -bwidth 200 -bheight 200 -tags new_profile_button -initial_state hidden \
     -command {
-        ::plugins::D_Flow_Espresso_Profile::prep
-        ::plugins::D_Flow_Espresso_Profile::demo_graph
-        if {$::settings(skin) == "DSx"} {
-            set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
+        if {$title_test == "A-Flow /" && [info commands ::plugins::A_Flow_Espresso_Profile::prep] ne ""} {
+            ::plugins::A_Flow_Espresso_Profile::prep
+            ::plugins::A_Flow_Espresso_Profile::demo_graph
+            if {$::settings(skin) == "DSx"} {
+                set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
+            }
+            dui page load Aflowset
+        } elseif {$title_test == "D-Flow /" } {
+            ::plugins::D_Flow_Espresso_Profile::prep
+            ::plugins::D_Flow_Espresso_Profile::demo_graph
+            if {$::settings(skin) == "DSx"} {
+                set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
+            }
+            dui page load Dflowset
         }
-        dui page load Dflowset
     }
 
 dui add dbutton "settings_1" 1330 220 \
@@ -1016,14 +1038,21 @@ dui add dbutton "settings_1" 1330 220 \
     -labelvariable {} -label_font [dui font get $font 12] -label_fill $font_colour -label_pos {0.5 0.5} \
     -command {
     set title_test [string range [ifexists ::settings(profile_title)] 0 7]
-    if {$title_test == "D-Flow /" } {
-        ::plugins::D_Flow_Espresso_Profile::prep
-        ::plugins::D_Flow_Espresso_Profile::demo_graph
+    if {$title_test == "A-Flow /" && [info commands ::plugins::A_Flow_Espresso_Profile::prep] ne ""} {
+        ::plugins::A_Flow_Espresso_Profile::prep
+        ::plugins::A_Flow_Espresso_Profile::demo_graph
         if {$::settings(skin) == "DSx"} {
             set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
         }
-        dui page load Dflowset
-        } else {
+        dui page load Aflowset
+    } elseif {$title_test == "D-Flow /" } {
+                ::plugins::D_Flow_Espresso_Profile::prep
+                ::plugins::D_Flow_Espresso_Profile::demo_graph
+                if {$::settings(skin) == "DSx"} {
+                    set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
+                }
+                dui page load Dflowset
+    } else {
         after 500 update_de1_explanation_chart
         say [translate {settings}] $::settings(sound_button_in)
         set_next_page off $::settings(settings_profile_type)
@@ -1045,14 +1074,21 @@ add_de1_widget "settings_1c" graph 1330 300 {
     $::preview_graph_advanced axis configure y -color #5a5d75 -tickfont Helv_6 -min 0.0 -max 12 -majorticks {1 2 3 4 5 6 7 8 9 10 11 12} -title [translate "Advanced"] -titlefont Helv_8 -titlecolor #5a5d75;
     bind $::preview_graph_advanced [platform_button_press] {
         set title_test [string range [ifexists ::settings(profile_title)] 0 7]
-        if {$title_test == "D-Flow /" } {
-            ::plugins::D_Flow_Espresso_Profile::prep
-            ::plugins::D_Flow_Espresso_Profile::demo_graph
+        if {$title_test == "A-Flow /" && [info commands ::plugins::A_Flow_Espresso_Profile::prep] ne ""} {
+            ::plugins::A_Flow_Espresso_Profile::prep
+            ::plugins::A_Flow_Espresso_Profile::demo_graph
             if {$::settings(skin) == "DSx"} {
                 set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
             }
-            dui page load Dflowset
-            } else {
+            dui page load Aflowset
+        } elseif {$title_test == "D-Flow /" } {
+                ::plugins::D_Flow_Espresso_Profile::prep
+                ::plugins::D_Flow_Espresso_Profile::demo_graph
+                if {$::settings(skin) == "DSx"} {
+                    set ::settings(grinder_dose_weight) [round_to_one_digits $::DSx_settings(bean_weight)]
+                }
+                dui page load Dflowset
+        } else {
             after 500 update_de1_explanation_chart
             say [translate {settings}] $::settings(sound_button_in)
             set_next_page off $::settings(settings_profile_type)
@@ -1060,8 +1096,8 @@ add_de1_widget "settings_1c" graph 1330 300 {
             set ::settings(active_settings_tab) $::settings(settings_profile_type)
             fill_advanced_profile_steps_listbox
             set_advsteps_scrollbar_dimensions
-            }
         }
+    }
 } -plotbackground #fff -width [rescale_x_skin 1050] -height [rescale_y_skin 450] -borderwidth 1 -background #FFFFFF -plotrelief raised  -plotpady 0 -plotpadx 10
 
 add_de1_button "settings_1" {say [translate {temperature}] $::settings(sound_button_in); change_espresso_temperature 0.5; profile_has_changed_set } 2380 230 2590 480
@@ -1093,7 +1129,7 @@ proc ::update_de1_plus_advanced_explanation_chart {} {
 rename ::setting_profile_type_to_text ::setting_profile_type_to_text_default
 proc ::setting_profile_type_to_text {} {
 	set title_test [string range [ifexists ::settings(profile_title)] 0 7]
-    if {$title_test == "D-Flow /" } {
+    if {$title_test == "D-Flow /" || $title_test == "A-Flow /"} {
         dui item show settings_1 new_profile_button*
         $::globals(widget_profile_name_to_save) configure -state disabled
     } else {


### PR DESCRIPTION
* fix compatibility issues due to profile title (A-Flow vs. D-Flow). Same is implemented in A-Flow plugin to be sure. However A-Flow is loaded first, therefore D-Flow overwrites A-Flow if both are enabled
* fix warning due to missing command by adding dummy command
* set version 2.3